### PR TITLE
Quick fix/delete archived screencast reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- New Branch -->
 # SchemaAnalyst
 
 <img src="https://github.com/schemaanalyst/logo/blob/master/schemaanalyst-logo-gh.png" height="250" alt="SchemaAnalyst - a mutation testing tool for relational database schemas">
@@ -588,4 +589,3 @@ Conference on Software Maintenance and Evolution, 2016. <a name="six"></a>
 ## License
 
 [GNU General Public License v3.0](./LICENSE.txt)
-

--- a/README.md
+++ b/README.md
@@ -220,14 +220,18 @@ files can be found in the `schemaanalyst/build/classes/main/parsedcasestudy/`
 directory after compiling the system.
 
 ## Tutorial <a name="tutorial"></a>
+<!--
 
-### Asciinema Recording <a name="asciicinema"></a>
+@Kapfhammer suggested replacing the archived screencast
+reference with an animated gif in the future.
+
+### Asciinema Recording <a name="asciicinema"></a>Tutorial
 
 Please watch this Asciinema recording that shows some of the key features of
 SchemaAnalyst, which are explained in more detail below.
 
 [![asciicast](https://asciinema.org/a/cuh7p68xg3ra65sl5rp8wimj5.png)](https://asciinema.org/a/cuh7p68xg3ra65sl5rp8wimj5)
-
+-->
 ---
 
 ### Help Menu <a name="help"></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- New Branch -->
 # SchemaAnalyst
 
 <img src="https://github.com/schemaanalyst/logo/blob/master/schemaanalyst-logo-gh.png" height="250" alt="SchemaAnalyst - a mutation testing tool for relational database schemas">


### PR DESCRIPTION
Me and @mmarconi have commented out the archived screen-cast reference so that said reference will not be reflected on SchemaAnalyst's GitHub webpage, while simultaneously serving as a placeholder for the reference to the proposed animated gif.  